### PR TITLE
Check errors for INDEX file

### DIFF
--- a/pkgsearch
+++ b/pkgsearch
@@ -34,9 +34,19 @@ def getIndex():
 
         return
     else:
-        r = requests.get(INDEX_URL)
-        out = open(INDEX_PATH, "w")
-        out.write(r.text)
+        try:
+            r = requests.get(INDEX_URL)
+        except requests.exceptions.RequestException as e:
+            print(f"[ERROR] unable to get INDEX file from URL - {e}")
+            return
+
+        if r.status_code == 200:
+            out = open(INDEX_PATH, "w")
+            out.write(r.text)
+        else:
+            print(
+                f"[ERROR] unable to get INDEX file from URL - HTTP Status-Code = {r.status_code}"
+            )
 
 
 def _printWrapper(pkg, size_mbytes):

--- a/pkgsearch
+++ b/pkgsearch
@@ -40,13 +40,21 @@ def getIndex():
             print(f"[ERROR] unable to get INDEX file from URL - {e}")
             return
 
-        if r.status_code == 200:
-            out = open(INDEX_PATH, "w")
-            out.write(r.text)
-        else:
+        if r.status_code != 200:
             print(
-                f"[ERROR] unable to get INDEX file from URL - HTTP Status-Code = {r.status_code}"
+                f"[ERROR] unable to get INDEX file from URL '{INDEX_URL}' - HTTP Status-Code = {r.status_code}"
             )
+            return
+        else:
+            try:
+                with open(INDEX_PATH, 'w') as out:
+                    try:
+                        out.write(r.text)
+                    except (IOError, OSError):
+                        print(f"[ERROR] Error writing to file {INDEX_PATH}")
+
+            except (FileNotFoundError, PermissionError, OSError):
+                print(f"[ERROR] Unable to open file {INDEX_PATH} for writing")
 
 
 def _printWrapper(pkg, size_mbytes):
@@ -64,7 +72,11 @@ def _printWrapper(pkg, size_mbytes):
 
 
 def queryIndex(needle):
-    f = open(INDEX_PATH, "r")
+    try:
+        f = open(INDEX_PATH, 'r')
+    except (FileNotFoundError, PermissionError, OSError):
+        print(f"[ERROR] Unable to open file {INDEX_PATH}")
+        return
 
     while True:
         data = f.readline()


### PR DESCRIPTION
- Catch exception for HTTP request to INDEX file in `getIndex` function
- Catch exceptions when writing/reading INDEX file in `getIndex`/`queryIndex` functions