### PR TITLE
Create cache directory for index + display version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # pkgsearch
 
-- pkgsearch is a easy to use tool to search the OpenBSD package repository. 
+- pkgsearch is a easy to use tool to search the OpenBSD package repository.
 - pkgsearch downloads the current package index to the local system so as to make a search request fast. This also means searches can be made offline.
 - pkgsearch also provides emoji output with the **"-e"** flag.
 
 ```
-usage: pkgsearch [-h] [-e] [-i] package
+usage: pkgsearch [-h] [-e] [-i] [-v] package
 ```
 **Example Output**
 
@@ -39,4 +39,4 @@ INDEX_URL = 'https://ftp.spline.de/pub/OpenBSD/7.3/packages/amd64/index.txt'
 ...
 ```
 ## Thanks
-**Laurent Cheylus (https://github.com/lcheylus)** - Code cleanup and improvements (PEP8). Also for improving error handling.   
+**Laurent Cheylus (https://github.com/lcheylus)** - Code cleanup and improvements (PEP8). Also for improving error handling.

--- a/pkgsearch
+++ b/pkgsearch
@@ -22,12 +22,12 @@ INDEX_PATH = HOME_DIR + "/" + INDEX_DOT
 
 # Flags used throughout the program
 # Do not change these
-emojiFlag = False
-indexFlag = False
+emoji_flag = False
+index_flag = False
 
 
 def get_index():
-    if exists(INDEX_PATH) and not indexFlag:
+    if exists(INDEX_PATH) and not index_flag:
         if DEBUG:
             print("[INFO] .index file already existing. Aborting download.")
 
@@ -57,7 +57,7 @@ def get_index():
 
 
 def _print_wrapper(pkg, size_mbytes):
-    if emojiFlag:
+    if emoji_flag:
         # 57 was chosen since the longest str was 55 chars
         # This should cover every package name currently in
         # the OpenBSD repository
@@ -119,10 +119,10 @@ def main():
 
     args = parser.parse_args()
 
-    global emojiFlag
-    emojiFlag = args.emoji
-    global indexFlag
-    indexFlag = args.index
+    global emoji_flag
+    emoji_flag = args.emoji
+    global index_flag
+    index_flag = args.index
 
     needle = args.package
 

--- a/pkgsearch
+++ b/pkgsearch
@@ -5,7 +5,7 @@ import os
 import emoji
 import argparse
 import requests
-from os.path import exists
+import sys
 
 PRG_NAME = "pkgsearch"
 PRG_VERSION = "0.4"
@@ -16,9 +16,9 @@ DEBUG = False
 # Change this to the closest mirror
 INDEX_URL = 'https://ftp.spline.de/pub/OpenBSD/7.3/packages/amd64/index.txt'
 
-HOME_DIR = os.getenv('HOME')
-INDEX_DOT = '.index'
-INDEX_PATH = HOME_DIR + "/" + INDEX_DOT
+CACHE_DIR = os.getenv('HOME') + '/.cache/' + PRG_NAME
+INDEX_FILE = 'index'
+INDEX_PATH = CACHE_DIR + '/' + INDEX_FILE
 
 # Flags used throughout the program
 # Do not change these
@@ -26,8 +26,21 @@ emoji_flag = False
 index_flag = False
 
 
+def create_cache_dir():
+    try:
+        os.makedirs(CACHE_DIR)
+    except FileExistsError:
+        if DEBUG:
+            print("[INFO] cache directory already existing. Aborting creation.")
+
+        return
+    except OSError as e:
+        print(f"[ERROR] unable to create cache directory {CACHE_DIR} - {e}")
+        sys.exit(0)
+
+
 def get_index():
-    if exists(INDEX_PATH) and not index_flag:
+    if os.path.exists(INDEX_PATH) and not index_flag:
         if DEBUG:
             print("[INFO] .index file already existing. Aborting download.")
 
@@ -126,6 +139,7 @@ def main():
 
     needle = args.package
 
+    create_cache_dir()
     get_index()
 
     query_index(needle)

--- a/pkgsearch
+++ b/pkgsearch
@@ -2,7 +2,6 @@
 
 import re
 import os
-import sys
 import emoji
 import argparse
 import requests
@@ -101,11 +100,6 @@ def query_index(needle):
     f.close()
 
 
-def print_version():
-    print("{} {}".format(PRG_NAME, PRG_VERSION))
-    sys.exit(0)
-
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("package")
@@ -114,6 +108,13 @@ def main():
     )
     parser.add_argument(
         "-i", "--index", help="download index", action="store_true"
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        help="display version",
+        action="version",
+        version=f"{PRG_NAME} {PRG_VERSION}",
     )
 
     args = parser.parse_args()

--- a/pkgsearch
+++ b/pkgsearch
@@ -27,7 +27,7 @@ emojiFlag = False
 indexFlag = False
 
 
-def getIndex():
+def get_index():
     if exists(INDEX_PATH) and not indexFlag:
         if DEBUG:
             print("[INFO] .index file already existing. Aborting download.")
@@ -57,7 +57,7 @@ def getIndex():
                 print(f"[ERROR] Unable to open file {INDEX_PATH} for writing")
 
 
-def _printWrapper(pkg, size_mbytes):
+def _print_wrapper(pkg, size_mbytes):
     if emojiFlag:
         # 57 was chosen since the longest str was 55 chars
         # This should cover every package name currently in
@@ -71,7 +71,7 @@ def _printWrapper(pkg, size_mbytes):
         print("{:<57} - Size: {:.2f}MB".format(pkg, size_mbytes))
 
 
-def queryIndex(needle):
+def query_index(needle):
     try:
         f = open(INDEX_PATH, 'r')
     except (FileNotFoundError, PermissionError, OSError):
@@ -96,12 +96,12 @@ def queryIndex(needle):
             # Convert to megabytes
             size_mbytes = int(size_bytes[0]) / 1048576
 
-            _printWrapper(pkg, size_mbytes)
+            _print_wrapper(pkg, size_mbytes)
 
     f.close()
 
 
-def printVersion():
+def print_version():
     print("{} {}".format(PRG_NAME, PRG_VERSION))
     sys.exit(0)
 
@@ -125,9 +125,9 @@ def main():
 
     needle = args.package
 
-    getIndex()
+    get_index()
 
-    queryIndex(needle)
+    query_index(needle)
 
 
 if __name__ == "__main__":

--- a/pkgsearch
+++ b/pkgsearch
@@ -50,13 +50,13 @@ def get_index():
             r = requests.get(INDEX_URL)
         except requests.exceptions.RequestException as e:
             print(f"[ERROR] unable to get INDEX file from URL - {e}")
-            return
+            sys.exit(0)
 
         if r.status_code != 200:
             print(
                 f"[ERROR] unable to get INDEX file from URL '{INDEX_URL}' - HTTP Status-Code = {r.status_code}"
             )
-            return
+            sys.exit(0)
         else:
             try:
                 with open(INDEX_PATH, 'w') as out:
@@ -64,9 +64,11 @@ def get_index():
                         out.write(r.text)
                     except (IOError, OSError):
                         print(f"[ERROR] Error writing to file {INDEX_PATH}")
+                        sys.exit(0)
 
             except (FileNotFoundError, PermissionError, OSError):
                 print(f"[ERROR] Unable to open file {INDEX_PATH} for writing")
+                sys.exit(0)
 
 
 def _print_wrapper(pkg, size_mbytes):


### PR DESCRIPTION
- Rename functions and global flags according to PEP-8
- Add program argument `-v/--version` to display version + remove unused `print_version` function
- Create cache directory `$HOME/.cache/pkgsearch/` to write/read `index` file
- Exit on error with sys.exit(0)