### PR TITLE
Add release argument to search packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ Make sure you set your desired mirror. This can be done by changing the **INDEX_
 MIRROR_URL = 'https://ftp.fr.openbsd.org/pub/OpenBSD'
 ```
 ## Thanks
-**Laurent Cheylus (https://github.com/lcheylus)** - Code cleanup and improvements (PEP8). Also for improving error handling. Adding the "-v" flag and further improving the code.
-**Cuddle (https://mastodon.bsd.cafe/@cuddle)** and **Laurent Cheylus (https://github.com/lcheylus)** - Cuddle: For improving the codebase and removing the need for a external Python package (Emojis). Laurent Cheylus: For reviewing/creating the PR.
+- **Laurent Cheylus (https://github.com/lcheylus)** - Code cleanup and improvements (PEP8). Also for improving error handling. Adding the "-v" flag and further improving the code.
+- **Cuddle (https://mastodon.bsd.cafe/@cuddle)** and **Laurent Cheylus (https://github.com/lcheylus)** - Cuddle: For improving the codebase and removing the need for a external Python package (Emojis). Laurent Cheylus: For reviewing/creating the PR.

--- a/README.md
+++ b/README.md
@@ -34,10 +34,8 @@ Make sure you set your desired mirror. This can be done by changing the **INDEX_
 
 **Example:**
 ```
-...
-INDEX_URL = 'https://ftp.spline.de/pub/OpenBSD/7.3/packages/amd64/index.txt'
-...
+MIRROR_URL = 'https://ftp.fr.openbsd.org/pub/OpenBSD'
 ```
 ## Thanks
-**Laurent Cheylus (https://github.com/lcheylus)** - Code cleanup and improvements (PEP8). Also for improving error handling. Adding the "-v" flag and further improving the code.   
+**Laurent Cheylus (https://github.com/lcheylus)** - Code cleanup and improvements (PEP8). Also for improving error handling. Adding the "-v" flag and further improving the code.
 **Cuddle (https://mastodon.bsd.cafe/@cuddle)** and **Laurent Cheylus (https://github.com/lcheylus)** - Cuddle: For improving the codebase and removing the need for a external Python package (Emojis). Laurent Cheylus: For reviewing/creating the PR.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # pkgsearch
 
 - pkgsearch is a easy to use tool to search the OpenBSD package repository.
-- pkgsearch downloads the current package index to the local system so as to make a search request fast. This also means searches can be made offline.
+- pkgsearch downloads the current package index for defined release (current default = 7.4) to the local system so as to make a search request fast. This also means searches can be made offline.
 - pkgsearch also provides emoji output with the **"-e"** flag.
 
 ```
-usage: pkgsearch [-h] [-e] [-i] [-v] package
+usage: pkgsearch [-h] [-e] [-i] [-r RELEASE] [-v] package
 ```
 **Example Output**
 
@@ -27,7 +27,12 @@ or with emojis displayed:
 $ ./pkgsearch -e python3
 ```
 
-pkgsearch was tested on the current OpenBSD release 7.3 but should also work on older systems.
+You could also search for an older OpenBSD release with `-r` argument:
+```
+$ ./pkgsearch -r 7.3 vim
+```
+
+pkgsearch was tested on the current OpenBSD release 7.4 but should also work on older systems.
 
 ## Hint
 Make sure you set your desired mirror. This can be done by changing the **INDEX_URL** variable in the pkgsearch script.

--- a/pkgsearch
+++ b/pkgsearch
@@ -3,6 +3,7 @@
 import re
 import os
 import argparse
+from packaging.version import InvalidVersion, parse
 import requests
 import sys
 
@@ -11,6 +12,9 @@ PRG_VERSION = "0.6"
 
 # Only for debugging
 DEBUG = False
+
+# Last OpenBSD release
+CURRENT_RELEASE = '7.4'
 
 # Change this to the closest mirror
 MIRROR_URL = 'https://ftp.spline.de/pub/OpenBSD/'
@@ -21,6 +25,26 @@ INDEX_FILE = 'index'
 INDEX_PATH = CACHE_DIR + '/' + INDEX_FILE
 
 PKG_EMOJI = '\U0001F4E6'
+
+
+def check_release(version: str):
+    """Checks version for OpenBSD release."""
+    try:
+        parse(version)
+    except InvalidVersion:
+        return False
+
+    # Check specific format major.minor for OpenBSD version
+    m = re.match(r'^\d{1}.\d{1}$', version)
+    if m is None:
+        return False
+
+    if (parse(version) > parse(CURRENT_RELEASE)) or (
+        parse(version) < parse('2.0')
+    ):
+        return False
+
+    return True
 
 
 def create_cache_dir():
@@ -118,6 +142,12 @@ def main():
         "-i", "--index", help="download index", action="store_true"
     )
     parser.add_argument(
+        "-r",
+        "--release",
+        help=f"release to search for packages (default = {CURRENT_RELEASE})",
+        default=CURRENT_RELEASE,
+    )
+    parser.add_argument(
         "-v",
         "--version",
         help="display version",
@@ -126,6 +156,10 @@ def main():
     )
 
     args = parser.parse_args()
+
+    if not check_release(args.release):
+        print(f"[ERROR] invalid release '{args.release}'")
+        sys.exit(0)
 
     needle = args.package
 

--- a/pkgsearch
+++ b/pkgsearch
@@ -13,7 +13,8 @@ PRG_VERSION = "0.6"
 DEBUG = False
 
 # Change this to the closest mirror
-INDEX_URL = 'https://ftp.spline.de/pub/OpenBSD/7.3/packages/amd64/index.txt'
+MIRROR_URL = 'https://ftp.spline.de/pub/OpenBSD/'
+INDEX_URL = '{0}/7.3/packages/amd64/index.txt'.format(MIRROR_URL)
 
 CACHE_DIR = '{0}/.cache/{1}'.format(os.getenv('HOME'), PRG_NAME)
 INDEX_FILE = 'index'
@@ -50,7 +51,7 @@ def get_index(index_flag: bool):
 
         if r.status_code != 200:
             print(
-                f"[ERROR] unable to get INDEX file from URL '{INDEX_URL}' - HTTP Status-Code = {r.status_code}"
+                f"[ERROR] unable to get INDEX file from URL '{MIRROR_URL}' - HTTP Status-Code = {r.status_code}"
             )
             sys.exit(0)
         else:

--- a/pkgsearch
+++ b/pkgsearch
@@ -17,12 +17,9 @@ DEBUG = False
 CURRENT_RELEASE = '7.4'
 
 # Change this to the closest mirror
-MIRROR_URL = 'https://ftp.spline.de/pub/OpenBSD/'
-INDEX_URL = '{0}/7.3/packages/amd64/index.txt'.format(MIRROR_URL)
+MIRROR_URL = 'https://ftp.fr.openbsd.org/pub/OpenBSD'
 
 CACHE_DIR = '{0}/.cache/{1}'.format(os.getenv('HOME'), PRG_NAME)
-INDEX_FILE = 'index'
-INDEX_PATH = CACHE_DIR + '/' + INDEX_FILE
 
 PKG_EMOJI = '\U0001F4E6'
 
@@ -60,43 +57,45 @@ def create_cache_dir():
         sys.exit(0)
 
 
-def get_index(index_flag: bool):
-    if os.path.exists(INDEX_PATH) and not index_flag:
+def get_index(version: str, index_path: str, index_flag: bool):
+    index_url = '{0}/{1}/packages/amd64/index.txt'.format(MIRROR_URL, version)
+
+    if os.path.exists(index_path) and not index_flag:
         if DEBUG:
-            print("[INFO] .index file already existing. Aborting download.")
+            print("[INFO] index file already existing. Aborting download.")
 
         return
     else:
         try:
-            r = requests.get(INDEX_URL)
+            r = requests.get(index_url)
         except requests.exceptions.RequestException as e:
             print(f"[ERROR] unable to get INDEX file from URL - {e}")
             sys.exit(0)
 
         if r.status_code != 200:
             print(
-                f"[ERROR] unable to get INDEX file from URL '{MIRROR_URL}' - HTTP Status-Code = {r.status_code}"
+                f"[ERROR] unable to get INDEX file from URL '{index_url}' - HTTP Status-Code = {r.status_code}"
             )
             sys.exit(0)
         else:
             try:
-                with open(INDEX_PATH, 'w') as out:
+                with open(index_path, 'w') as out:
                     try:
                         out.write(r.text)
                     except (IOError, OSError):
-                        print(f"[ERROR] Error writing to file {INDEX_PATH}")
+                        print(f"[ERROR] Error writing to file {index_path}")
                         sys.exit(0)
 
             except (FileNotFoundError, PermissionError, OSError):
-                print(f"[ERROR] Unable to open file {INDEX_PATH} for writing")
+                print(f"[ERROR] Unable to open file {index_path} for writing")
                 sys.exit(0)
 
 
-def query_index(needle: str, emoji_flag: bool):
+def query_index(index_path: str, needle: str, emoji_flag: bool):
     try:
-        f = open(INDEX_PATH, 'r')
+        f = open(index_path, 'r')
     except (FileNotFoundError, PermissionError, OSError):
-        print(f"[ERROR] Unable to open file {INDEX_PATH}")
+        print(f"[ERROR] Unable to open file {index_path}")
         return
 
     while True:
@@ -161,12 +160,13 @@ def main():
         print(f"[ERROR] invalid release '{args.release}'")
         sys.exit(0)
 
-    needle = args.package
+    index_path = '{0}/index-{1}'.format(CACHE_DIR, args.release)
 
     create_cache_dir()
-    get_index(args.index)
+    get_index(args.release, index_path, args.index)
 
-    query_index(needle, args.emoji)
+    print(f"Search packages '{args.package}' for release {args.release}")
+    query_index(index_path, args.package, args.emoji)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add `-r` argument to define OpenBSD release to search packages
- Define default release = 7.4 (current OpenBSD release)
- Use `release` argument to search packages
- Index file is now saved in `${CACHE_DIR}/index-${release}`
- Udpate README with `-r` argument
- Modify MIRROR_URL to to https://ftp.fr.openbsd.org/pub/OpenBSD - Previous mirror URL https://ftp.spline.de/pub/OpenBSD have no index file for amd64 packages with OpenBSD 7.4 release :(