### PR TITLE
Add option to search packages in snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # pkgsearch
 
 - pkgsearch is a easy to use tool to search the OpenBSD package repository.
-- pkgsearch downloads the current package index for defined release (current default = 7.4) to the local system so as to make a search request fast. This also means searches can be made offline.
+- pkgsearch downloads the current package index for defined release (current default = 7.4) or snapshots to the local system so as to make a search request fast. This also means searches can be made offline.
 - pkgsearch also provides emoji output with the **"-e"** flag.
 
 ```
-usage: pkgsearch [-h] [-e] [-i] [-r RELEASE] [-v] package
+usage: pkgsearch [-h] [-e] [-i] [-r RELEASE | -s] [-v] package
 ```
 **Example Output**
 
@@ -42,6 +42,6 @@ Make sure you set your desired mirror. This can be done by changing the **INDEX_
 MIRROR_URL = 'https://ftp.fr.openbsd.org/pub/OpenBSD'
 ```
 ## Thanks
-- **Laurent Cheylus (https://github.com/lcheylus)** - Code cleanup and improvements (PEP8). Also for improving error handling. Adding the "-v" flag and further improving the code. Adding the "-r" option and improving the code further.   
+- **Laurent Cheylus (https://github.com/lcheylus)** - Code cleanup and improvements (PEP8). Also for improving error handling. Adding the "-v" flag and further improving the code. Adding the "-r" option and improving the code further.
 - **Cuddle (https://mastodon.bsd.cafe/@cuddle)** and **Laurent Cheylus (https://github.com/lcheylus)** - Cuddle: For improving the codebase and removing the need for a external Python package (Emojis). Laurent Cheylus: For reviewing/creating the PR.
-- **Alexander Naumov** (https://github.com/alexander-naumov) - Suggestions regarding debugging.   
+- **Alexander Naumov** (https://github.com/alexander-naumov) - Suggestions regarding debugging.

--- a/pkgsearch
+++ b/pkgsearch
@@ -57,8 +57,11 @@ def create_cache_dir():
         sys.exit(0)
 
 
-def get_index(version: str, index_path: str, index_flag: bool):
-    index_url = '{0}/{1}/packages/amd64/index.txt'.format(MIRROR_URL, version)
+def get_index(snapshot: bool, version: str, index_path: str, index_flag: bool):
+    if snapshot:
+        index_url = '{0}/snapshots/packages/amd64/index.txt'.format(MIRROR_URL)
+    else:
+        index_url = '{0}/{1}/packages/amd64/index.txt'.format(MIRROR_URL, version)
 
     if os.path.exists(index_path) and not index_flag:
         if DEBUG:
@@ -140,12 +143,21 @@ def main():
     parser.add_argument(
         "-i", "--index", help="download index", action="store_true"
     )
-    parser.add_argument(
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
         "-r",
         "--release",
         help=f"release to search for packages (default = {CURRENT_RELEASE})",
         default=CURRENT_RELEASE,
     )
+    group.add_argument(
+        "-s",
+        "--snapshot",
+        help="search for packages in snapshots",
+        action="store_true"
+    )
+
     parser.add_argument(
         "-v",
         "--version",
@@ -160,12 +172,19 @@ def main():
         print(f"[ERROR] invalid release '{args.release}'")
         sys.exit(0)
 
-    index_path = '{0}/index-{1}'.format(CACHE_DIR, args.release)
+    if args.snapshot:
+        index_path = '{0}/index-snapshots'.format(CACHE_DIR)
+    else:
+        index_path = '{0}/index-{1}'.format(CACHE_DIR, args.release)
 
     create_cache_dir()
-    get_index(args.release, index_path, args.index)
 
-    print(f"Search packages '{args.package}' for release {args.release}")
+    get_index(args.snapshot, args.release, index_path, args.index)
+
+    if args.snapshot:
+        print(f"Search packages '{args.package}' in snapshots")
+    else:
+        print(f"Search packages '{args.package}' for release {args.release}")
     query_index(index_path, args.package, args.emoji)
 
 


### PR DESCRIPTION
- Add `-s` argument and exclusive mutual group with `-r RELEASE`
- With `-s` argument, download index for snapshots (URL as `https://ftp.fr.openbsd.org/pub/OpenBSD/snapshots/packages/amd64/index.txt`) and search packages in it.