### PR TITLE
 Add argument arch to search for packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # pkgsearch
 
 - pkgsearch is a easy to use tool to search the OpenBSD package repository.
-- pkgsearch downloads the current package index for defined release (current default = 7.4) or snapshots to the local system so as to make a search request fast. This also means searches can be made offline.
+- pkgsearch downloads the current package index for defined release (current default = 7.4) or snapshots and defined architecture (default = amd64) to the local system so as to make a search request fast. This also means searches can be made offline.
 - pkgsearch also provides emoji output with the **"-e"** flag.
 
 ```
-usage: pkgsearch [-h] [-e] [-i] [-r RELEASE | -s] [-v] package
+usage: pkgsearch [-h] [-e] [-i] [-r RELEASE | -s] [-a ARCH] [-v] package
 ```
 **Example Output**
 
@@ -42,6 +42,6 @@ Make sure you set your desired mirror. This can be done by changing the **INDEX_
 MIRROR_URL = 'https://ftp.fr.openbsd.org/pub/OpenBSD'
 ```
 ## Thanks
-- **Laurent Cheylus (https://github.com/lcheylus)** - Code cleanup and improvements (PEP8). Also for improving error handling. Adding the "-v" flag and further improving the code. Adding the "-r" option and improving the code further. Adding the "-s" (snapshot) option.   
+- **Laurent Cheylus (https://github.com/lcheylus)** - Code cleanup and improvements (PEP8). Also for improving error handling. Adding the "-v" flag and further improving the code. Adding the "-r" option and improving the code further. Adding the "-s" (snapshot) option.
 - **Cuddle (https://mastodon.bsd.cafe/@cuddle)** and **Laurent Cheylus (https://github.com/lcheylus)** - Cuddle: For improving the codebase and removing the need for a external Python package (Emojis). Laurent Cheylus: For reviewing/creating the PR.
 - **Alexander Naumov** (https://github.com/alexander-naumov) - Suggestions regarding debugging.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@
 
 ```
 usage: pkgsearch [-h] [-e] [-i] [-r RELEASE | -s] [-a ARCH] [-v] package
+
+positional arguments:
+  package
+
+options:
+  -h, --help            show this help message and exit
+  -e, --emoji           turn on emoji output
+  -i, --index           download index
+  -r RELEASE, --release RELEASE
+                        release to search for packages (default = 7.4)
+  -s, --snapshot        search for packages in snapshots
+  -a ARCH, --arch ARCH  arch to search for packages (default = amd64)
+  -v, --version         display version
 ```
 **Example Output**
 

--- a/pkgsearch
+++ b/pkgsearch
@@ -13,6 +13,19 @@ PRG_VERSION = "0.8"
 # Only for debugging
 DEBUG = False
 
+# Available architectures for packages
+ARCHS = [
+    'aarch64',
+    'amd64',
+    'arm',
+    'i386',
+    'mips64',
+    'powerpc',
+    'powerpc64',
+    'riscv64',
+    'sparc64',
+]
+
 # Last OpenBSD release
 CURRENT_RELEASE = '7.4'
 
@@ -57,11 +70,15 @@ def create_cache_dir():
         sys.exit(0)
 
 
-def get_index(snapshot: bool, version: str, index_path: str, index_flag: bool):
+def get_index(snapshot: bool, version: str, arch: str, index_path: str, index_flag: bool):
     if snapshot:
-        index_url = '{0}/snapshots/packages/amd64/index.txt'.format(MIRROR_URL)
+        index_url = '{0}/snapshots/packages/{1}/index.txt'.format(
+            MIRROR_URL, arch
+        )
     else:
-        index_url = '{0}/{1}/packages/amd64/index.txt'.format(MIRROR_URL, version)
+        index_url = '{0}/{1}/packages/{2}/index.txt'.format(
+            MIRROR_URL, version, arch
+        )
 
     if os.path.exists(index_path) and not index_flag:
         if DEBUG:
@@ -85,6 +102,9 @@ def get_index(snapshot: bool, version: str, index_path: str, index_flag: bool):
                 with open(index_path, 'w') as out:
                     try:
                         out.write(r.text)
+                        if DEBUG:
+                            print(f"[INFO] write index file {index_path}")
+
                     except (IOError, OSError):
                         print(f"[ERROR] Error writing to file {index_path}")
                         sys.exit(0)
@@ -155,7 +175,14 @@ def main():
         "-s",
         "--snapshot",
         help="search for packages in snapshots",
-        action="store_true"
+        action="store_true",
+    )
+
+    parser.add_argument(
+        "-a",
+        "--arch",
+        help="arch to search for packages (default = amd64)",
+        default='amd64',
     )
 
     parser.add_argument(
@@ -172,19 +199,28 @@ def main():
         print(f"[ERROR] invalid release '{args.release}'")
         sys.exit(0)
 
+    if args.arch not in ARCHS:
+        print(f"[ERROR] invalid arch '{args.arch}'")
+        print("Available archs: ", end='')
+        for arch in ARCHS:
+            print(f"{arch} ", end='')
+        print("")
+        sys.exit(0)
+
     if args.snapshot:
-        index_path = '{0}/index-snapshots'.format(CACHE_DIR)
+        index_path = '{0}/index-{1}-snapshots'.format(CACHE_DIR, args.arch)
     else:
-        index_path = '{0}/index-{1}'.format(CACHE_DIR, args.release)
+        index_path = '{0}/index-{1}-{2}'.format(CACHE_DIR, args.arch, args.release)
 
     create_cache_dir()
 
-    get_index(args.snapshot, args.release, index_path, args.index)
+    get_index(args.snapshot, args.release, args.arch, index_path, args.index)
 
     if args.snapshot:
-        print(f"Search packages '{args.package}' in snapshots")
+        print(f"Search packages '{args.package}' in snapshots for arch {args.arch}")
     else:
-        print(f"Search packages '{args.package}' for release {args.release}")
+        print(f"Search packages '{args.package}' for release {args.release} / arch {args.arch}")
+
     query_index(index_path, args.package, args.emoji)
 
 


### PR DESCRIPTION
- add argument -a/--arch to search for packages (default = amd64)
- add list of available architectures for packages
- check if argument `arch` is in available archs
- index file is now `index-{arch}-{version}` or `index-{arch}-snapshots`

- update README.md for arch argument and add detailed usage