### PR TITLE
Add check for regexp used in package argument

### DIFF
--- a/pkgsearch
+++ b/pkgsearch
@@ -214,6 +214,12 @@ def main():
 
     args = parser.parse_args()
 
+    try:
+        re.compile(args.package)
+    except re.error:
+        print(f"[ERROR] invalid regexp '{args.package}' to search packages")
+        sys.exit(0)
+
     if not check_release(args.release):
         print(f"[ERROR] invalid release '{args.release}'")
         sys.exit(0)


### PR DESCRIPTION
Add a try/except to check if the regexp used for `package` argument is valid.